### PR TITLE
Reverse allDefinitions so that more recent definitions have priority

### DIFF
--- a/fixtures/import-shadowed/a.graphql
+++ b/fixtures/import-shadowed/a.graphql
@@ -1,0 +1,5 @@
+# import B from "b.graphql"
+
+type Query {
+    b: B!
+}

--- a/fixtures/import-shadowed/b.graphql
+++ b/fixtures/import-shadowed/b.graphql
@@ -1,0 +1,5 @@
+# import X from './c.graphql'
+
+type B {
+    x: X
+}

--- a/fixtures/import-shadowed/c.graphql
+++ b/fixtures/import-shadowed/c.graphql
@@ -1,0 +1,4 @@
+scalar X
+type B {
+  private: Int
+}

--- a/package.json
+++ b/package.json
@@ -6,17 +6,28 @@
   },
   "license": "MIT",
   "repository": "git@github.com:graphcool/graphql-import.git",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"
   },
   "nyc": {
-    "extension": [".ts"],
-    "require": ["ts-node/register"],
-    "include": ["src/**/*.ts"],
-    "exclude": ["**/*.d.ts", "**/*.test.ts"],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "include": [
+      "src/**/*.ts"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "**/*.test.ts"
+    ],
     "all": true,
     "sourceMap": true,
     "instrument": true
@@ -24,15 +35,11 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "rm -rf dist && tsc -d",
-    "testlocal":
-      "npm run build && nyc --reporter lcov --reporter text ava-ts -u --verbose src/**/*.test.ts",
-    "test-only":
-      "npm run build && mkdir -p ~/reports && nyc --reporter lcov ava-ts --verbose src/**/*.test.ts --tap | tap-xunit > ~/reports/ava.xml",
+    "testlocal": "npm run build && nyc --reporter lcov --reporter text ava-ts -u --verbose src/**/*.test.ts",
+    "test-only": "npm run build && mkdir -p ~/reports && nyc --reporter lcov ava-ts --verbose src/**/*.test.ts --tap | tap-xunit > ~/reports/ava.xml",
     "test": "tslint src/**/*.ts && npm run test-only",
-    "docs":
-      "typedoc --out docs src/index.ts --hideGenerator --exclude **/*.test.ts",
-    "docs:publish":
-      "cp ./now.json ./docs && cd docs && now --public -f && now alias && now rm --yes --safe graphql-import & cd .."
+    "docs": "typedoc --out docs src/index.ts --hideGenerator --exclude **/*.test.ts",
+    "docs:publish": "cp ./now.json ./docs && cd docs && now --public -f && now alias && now rm --yes --safe graphql-import & cd .."
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
@@ -47,12 +54,13 @@
     "nyc": "11.8.0",
     "tap-xunit": "2.3.0",
     "ts-node": "6.0.3",
-    "tslint": "5.10.0",
-    "tslint-config-standard": "7.0.0",
+    "tslint": "^5.10.0",
+    "tslint-config-standard": "^7.0.0",
     "typedoc": "0.11.1",
-    "typescript": "2.8.3"
+    "typescript": "^2.8.3"
   },
   "dependencies": {
+    "jshint": "^2.9.5",
     "lodash": "^4.17.4"
   }
 }

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,4 +1,4 @@
-import { keyBy, uniqBy, includes } from 'lodash'
+import { keyBy, uniqBy, includes, reverse } from 'lodash'
 import {
   DocumentNode,
   TypeDefinitionNode,
@@ -40,7 +40,7 @@ export function completeDefinitionPool(
 ): ValidDefinitionNode[] {
   const visitedDefinitions: { [name: string]: boolean } = {}
   while (newTypeDefinitions.length > 0) {
-    const schemaMap: DefinitionMap = keyBy(allDefinitions, d => d.name.value)
+    const schemaMap: DefinitionMap = keyBy(reverse(allDefinitions), d => d.name.value)
     const newDefinition = newTypeDefinitions.shift()
     if (visitedDefinitions[newDefinition.name.value]) {
       continue

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -744,3 +744,18 @@ test('missing type on directive', t => {
     `Directive first: Couldn't find type first in any of the schemas.`,
   )
 })
+
+test('import schema with shadowed type', t => {
+  const expectedSDL = `\
+type Query {
+  b: B!
+}
+
+type B {
+  x: X
+}
+
+scalar X
+`
+  t.is(importSchema('fixtures/import-shadowed/a.graphql'), expectedSDL)
+})


### PR DESCRIPTION
This fixes a subtle bug.

Consider creating a type `B` (let's call it `B1`) that depends on a value `X` which must be imported from another file. That other file also contains a type called `B` (call it `B2`). The resulting schema will include `B2`, but not `B1`. This is counterintuitive, because `B1` was written "later" and should have overridden `B2`.

More practically: if you use Prisma to define a `User` type, and then redefine a new `User` type for your application schema, and then import the application-`User` and also anything from the Prisma schema, you will be surprised to see that the Prisma-`User` is in your final schema, not your application-`User`.

The reason this happens is that as graphql-import creates an array of all the types it's seen by appending types as it recurses deeper into the import tree. Later, it collapses that array using Lodash's `keyBy` function and the type names. When `keyBy` encounters multiple names with the same value, it chooses the last one. This means that if two files have a name conflict, the one that was seen last -- which was the one that came EARLIEST in the import sequence -- wins! This is wrong; types that are defined later have precedence over types that were defined earlier.

We fix this by reversing the array before applying `keyBy`.

In the unit test, we create a `Query` that imports a type `B`. The file that defines `B` imports a scalar `X` from a file that itself contains an earlier version of `B` with a private field. 

Without this PR, the unit test outputs:
```graphql
type Query {
  b: B!
}

type B {
  private: Int # this should have been overridden 
}

scalar X
```
This is wrong because the merged schema contains the earlier version of `B` with the private field (and no `X` attribute)

With this PR, the unit test outputs: 
```graphql
type Query {
  b: B!
}

type B {
  x: X # properly overridden
}

scalar X
```
This is right, because it's the more recently-defined version of `B`.
