### PR TITLE
Using glob pattern to import schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,65 @@ type Mutation {
 }
 ```
 
+### Importing with globs
+
+You can also import every `.graphql` files in your project using globs patterns.
+
+Assume the following directory structure:
+
+```
+.
+├── a.graphql
+├── b.graphql
+```
+
+`a.graphql`
+
+```graphql
+type Query {
+  first: String!
+  second: Float
+}
+```
+
+`b.graphql`
+
+```graphql
+type Book {
+  id: ID!
+  name: String
+  read: Boolean!
+}
+
+type Query {
+  book(id: ID!): Book
+}
+
+type Mutation {
+  readBook(id: ID!): Book
+}
+```
+
+Running `console.log(importSchema('*.graphql'))` produces the following output:
+
+```graphql
+type Query {
+  first: String!
+  second: Float
+  book(id: ID!): Book
+}
+
+type Mutation {
+  readBook(id: ID!): Book
+}
+
+type Book {
+  id: ID!
+  name: String
+  read: Boolean!
+}
+```
+
 Please refer to [`src/index.test.ts`](https://github.com/graphcool/graphql-import/blob/master/src/index.test.ts) for more examples.
 
 ## Development

--- a/fixtures/import-glob/a.graphql
+++ b/fixtures/import-glob/a.graphql
@@ -1,0 +1,4 @@
+type Query {
+  first: String!
+  second: Float
+}

--- a/fixtures/import-glob/b.graphql
+++ b/fixtures/import-glob/b.graphql
@@ -1,0 +1,13 @@
+type Book {
+  id: ID!
+  name: String
+  read: Boolean!
+}
+
+type Query {
+  book(id: ID!): Book
+}
+
+type Mutation {
+  readBook(id: ID!): Book
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
+    "@types/glob": "^5.0.35",
     "@types/graphql": "0.12.6",
     "@types/lodash": "4.14.109",
     "@types/node": "9.6.19",
@@ -53,6 +54,7 @@
     "typescript": "2.8.3"
   },
   "dependencies": {
+    "glob": "^7.1.2",
     "lodash": "^4.17.4"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -671,6 +671,27 @@ type Shared {
   t.is(importSchema('fixtures/global/a.graphql', { shared }), expectedSDL)
 })
 
+test('glob import', t => {
+  const expectedSDL = `\
+type Query {
+  first: String!
+  second: Float
+  book(id: ID!): Book
+}
+
+type Mutation {
+  readBook(id: ID!): Book
+}
+
+type Book {
+  id: ID!
+  name: String
+  read: Boolean!
+}
+`
+  t.is(importSchema('fixtures/import-glob/*.graphql'), expectedSDL)
+})
+
 test('missing type on type', t => {
   const err = t.throws(
     () => importSchema('fixtures/type-not-found/a.graphql'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as glob from 'glob'
 import {
   DefinitionNode,
   parse,
@@ -26,6 +27,11 @@ export interface RawModule {
 const rootFields = ['Query', 'Mutation', 'Subscription']
 
 const read = (schema: string, schemas?: { [key: string]: string }) => {
+  if (schema.includes('*')) {
+    return glob.sync(schema)
+      .map(filePath => fs.readFileSync(filePath, { encoding: 'utf8' }))
+      .join('\n')
+  }
   if (isFile(schema)) {
     return fs.readFileSync(schema, { encoding: 'utf8' })
   }


### PR DESCRIPTION
Hi everybody!

I'm just starting a new Apollo server 2.0 (oh yeah!) and I would like propose a new way to import schemas.

My idea is  quite simple -> using globs!

So with this feature, we can setup a server like this:

```ts
import { ApolloServer } from "apollo-server"
import { importSchema } from "graphql-import"

import * as labs from "./services/labs"

const typeDefs = importSchema(`services/**/*.graphql`)

const resolvers = {
  ...labs.resolvers
}

const server = new ApolloServer({ typeDefs, resolvers })

server.listen().then(({ url }) =>
  console.log(`🚀  Server ready at ${url}`),
)
```

No more manual imports and the configuration is really simple, now I can add any `myService.graphql` into my `services` folder and it's a part of my schema 🎉 

Next step for me, add a `combineResolvers` and I can have a beautiful folders structure without thinking of importing everyting 😄 