### PR TITLE
Implemented SCHEMA_DEFINITION support

### DIFF
--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,18 +1,18 @@
 import { keyBy, uniqBy, includes } from 'lodash'
 import {
-	DocumentNode,
-	TypeDefinitionNode,
-	ObjectTypeDefinitionNode,
-	InputObjectTypeDefinitionNode,
-	TypeNode,
-	NamedTypeNode,
-	DirectiveNode,
-	DirectiveDefinitionNode,
-	InputValueDefinitionNode,
-	FieldDefinitionNode,
-	SchemaDefinitionNode,
-	OperationTypeDefinitionNode,
-	OperationTypeNode
+  DocumentNode,
+  TypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  TypeNode,
+  NamedTypeNode,
+  DirectiveNode,
+  DirectiveDefinitionNode,
+  InputValueDefinitionNode,
+  FieldDefinitionNode,
+  SchemaDefinitionNode,
+  OperationTypeDefinitionNode,
+  OperationTypeNode
 } from 'graphql'
 
 const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID']
@@ -20,8 +20,8 @@ const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID']
 const builtinDirectives = ['deprecated', 'skip', 'include']
 
 export type ValidDefinitionNode =
-	| DirectiveDefinitionNode
-	| TypeDefinitionNode
+  | DirectiveDefinitionNode
+  | TypeDefinitionNode
 
 export interface DefinitionMap {
   [key: string]: ValidDefinitionNode
@@ -37,9 +37,9 @@ export interface DefinitionMap {
  * @returns Final collection of type definitions for the resulting schema
  */
 export function completeDefinitionPool(
-	allDefinitions: ValidDefinitionNode[],
-	definitionPool: ValidDefinitionNode[],
-	newTypeDefinitions: ValidDefinitionNode[],
+  allDefinitions: ValidDefinitionNode[],
+  definitionPool: ValidDefinitionNode[],
+  newTypeDefinitions: ValidDefinitionNode[],
 ): ValidDefinitionNode[] {
   const visitedDefinitions: { [name: string]: boolean } = {}
   while (newTypeDefinitions.length > 0) {
@@ -50,11 +50,11 @@ export function completeDefinitionPool(
     }
 
     const collectedTypedDefinitions = collectNewTypeDefinitions(
-			allDefinitions,
-			definitionPool,
-			newDefinition,
-			schemaMap,
-		)
+      allDefinitions,
+      definitionPool,
+      newDefinition,
+      schemaMap,
+    )
     newTypeDefinitions.push(...collectedTypedDefinitions)
     definitionPool.push(...collectedTypedDefinitions)
 
@@ -76,9 +76,9 @@ export function getSchemaDefinitionNode(operationTypes: any[]): SchemaDefinition
     type: {
       kind: 'NamedType',
       name: {
-		  kind: 'Name',
-		  value: typeName,
-	  }
+        kind: 'Name',
+        value: typeName,
+      }
     }
   })
 
@@ -103,10 +103,10 @@ export function getSchemaDefinitionNode(operationTypes: any[]): SchemaDefinition
  * @returns All relevant type definitions to add to the final schema
  */
 function collectNewTypeDefinitions(
-	allDefinitions: ValidDefinitionNode[],
-	definitionPool: ValidDefinitionNode[],
-	newDefinition: ValidDefinitionNode,
-	schemaMap: DefinitionMap,
+  allDefinitions: ValidDefinitionNode[],
+  definitionPool: ValidDefinitionNode[],
+  newDefinition: ValidDefinitionNode,
+  schemaMap: DefinitionMap,
 ): ValidDefinitionNode[] {
   let newTypeDefinitions: ValidDefinitionNode[] = []
 
@@ -123,10 +123,10 @@ function collectNewTypeDefinitions(
     newDefinition.fields.forEach(collectNode)
 
     const interfaceImplementations = allDefinitions.filter(
-			d =>
-				d.kind === 'ObjectTypeDefinition' &&
-				d.interfaces.some(i => i.name.value === interfaceName),
-		)
+      d =>
+        d.kind === 'ObjectTypeDefinition' &&
+        d.interfaces.some(i => i.name.value === interfaceName),
+    )
     newTypeDefinitions.push(...interfaceImplementations)
   }
 
@@ -144,24 +144,24 @@ function collectNewTypeDefinitions(
   }
 
   if (newDefinition.kind === 'ObjectTypeDefinition') {
-		// collect missing interfaces
+    // collect missing interfaces
     newDefinition.interfaces.forEach(int => {
       if (!definitionPool.some(d => d.name.value === int.name.value)) {
         const interfaceName = int.name.value
         const interfaceMatch = schemaMap[interfaceName]
         if (!interfaceMatch) {
           throw new Error(
-						`Couldn't find interface ${interfaceName} in any of the schemas.`,
-					)
+            `Couldn't find interface ${interfaceName} in any of the schemas.`,
+          )
         }
         newTypeDefinitions.push(schemaMap[int.name.value])
       }
     })
 
-		// iterate over all fields
+    // iterate over all fields
     newDefinition.fields.forEach(field => {
       collectNode(field)
-			// collect missing argument input types
+      // collect missing argument input types
       field.arguments.forEach(collectNode)
     })
   }
@@ -172,16 +172,16 @@ function collectNewTypeDefinitions(
     const nodeType = getNamedType(node.type)
     const nodeTypeName = nodeType.name.value
 
-		// collect missing argument input types
+    // collect missing argument input types
     if (
-			!definitionPool.some(d => d.name.value === nodeTypeName) &&
-			!includes(builtinTypes, nodeTypeName)
-		) {
+      !definitionPool.some(d => d.name.value === nodeTypeName) &&
+      !includes(builtinTypes, nodeTypeName)
+    ) {
       const argTypeMatch = schemaMap[nodeTypeName]
       if (!argTypeMatch) {
         throw new Error(
-					`Field ${node.name.value}: Couldn't find type ${nodeTypeName} in any of the schemas.`,
-				)
+          `Field ${node.name.value}: Couldn't find type ${nodeTypeName} in any of the schemas.`,
+        )
       }
       newTypeDefinitions.push(argTypeMatch)
     }
@@ -192,16 +192,16 @@ function collectNewTypeDefinitions(
   function collectDirective(directive: DirectiveNode) {
     const directiveName = directive.name.value
     if (
-			!definitionPool.some(d => d.name.value === directiveName) &&
-			!includes(builtinDirectives, directiveName)
-		) {
+      !definitionPool.some(d => d.name.value === directiveName) &&
+      !includes(builtinDirectives, directiveName)
+    ) {
       const directive = schemaMap[directiveName] as DirectiveDefinitionNode
       if (!directive) {
         throw new Error(
-					`Directive ${directiveName}: Couldn't find type ${
-					directiveName
-					} in any of the schemas.`,
-				)
+          `Directive ${directiveName}: Couldn't find type ${
+          directiveName
+          } in any of the schemas.`,
+        )
       }
       directive.arguments.forEach(collectNode)
 

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -11,7 +11,8 @@ import {
 	InputValueDefinitionNode,
 	FieldDefinitionNode,
 	SchemaDefinitionNode,
-	OperationTypeDefinitionNode
+	OperationTypeDefinitionNode,
+	OperationTypeNode
 } from 'graphql'
 
 const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID']
@@ -68,9 +69,10 @@ export function completeDefinitionPool(
  * for example: QueryType, MutationType (used by neo4j)
  */
 export function getSchemaDefinitionNode(operationTypes: any[]): SchemaDefinitionNode {
-  const mapOperationType: (s: string) => OperationTypeDefinitionNode = (typeName: string) => ({
+  const operations: OperationTypeNode[] = ['query', 'mutation', 'subscription']
+  const mapOperationType: (s: string, i: number) => OperationTypeDefinitionNode = (typeName: string, i: number) => ({
     kind: 'OperationTypeDefinition',
-    operation: 'query',
+    operation: operations[i],
     type: {
       kind: 'NamedType',
       name: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { flatten, groupBy, includes, keyBy } from 'lodash'
 import * as path from 'path'
 
-import { completeDefinitionPool, ValidDefinitionNode } from './definition'
+import { completeDefinitionPool, ValidDefinitionNode, getSchemaDefinitionNode } from './definition'
 
 /**
  * Describes the information from a single import line
@@ -127,7 +127,12 @@ export function importSchema(
 		flatten(typeDefinitions),
 	)
 
-	// Return the schema as string
+  const existingRootFields = rootFields.filter(x => firstTypes.find(y => y.name.value === x))
+  const node = getSchemaDefinitionNode(existingRootFields)
+
+  document.definitions.push(node)
+
+  // Return the schema as string
   return print(document)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,11 @@ export function importSchema(
   const sdl = read(schema, schemas) || schema
   const document = getDocumentFromSDL(sdl)
 
+  const needSchemaDefinitionNode =
+    (rootFields[0] !== 'Query') ||
+    (rootFields[1] !== 'Mutation') ||
+    (rootFields[2] !== 'Subscription')
+
   // Recursively process the imports, starting by importing all types from the initial schema
   let { allDefinitions, typeDefinitions } = collectDefinitions(
     ['*'],
@@ -127,10 +132,12 @@ export function importSchema(
     flatten(typeDefinitions),
   )
 
-  const existingRootFields = rootFields.filter(x => firstTypes.find(y => y.name.value === x))
-  const node = getSchemaDefinitionNode(existingRootFields)
+  if (needSchemaDefinitionNode) {
+    const existingRootFields = rootFields.filter(x => firstTypes.find(y => y.name.value === x))
+    const node = getSchemaDefinitionNode(existingRootFields)
 
-  document.definitions.push(node)
+    document.definitions.push(node)
+  }
 
   // Return the schema as string
   return print(document)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs'
 import {
-	DefinitionNode,
-	parse,
-	print,
-	TypeDefinitionNode,
-	GraphQLObjectType,
-	ObjectTypeDefinitionNode,
-	DocumentNode,
-	Kind,
+  DefinitionNode,
+  parse,
+  print,
+  TypeDefinitionNode,
+  GraphQLObjectType,
+  ObjectTypeDefinitionNode,
+  DocumentNode,
+  Kind,
 } from 'graphql'
 import { flatten, groupBy, includes, keyBy } from 'lodash'
 import * as path from 'path'
@@ -39,20 +39,20 @@ const isFile = f => f.endsWith('.graphql')
  * @returns Processed import line
  */
 export function parseImportLine(importLine: string): RawModule {
-	// Apply regex to import line
+  // Apply regex to import line
   const matches = importLine.match(/^import (\*|(.*)) from ('|")(.*)('|");?$/)
   if (!matches || matches.length !== 6 || !matches[4]) {
     throw new Error(`Too few regex matches: ${matches}`)
   }
 
-	// Extract matches into named variables
+  // Extract matches into named variables
   const [, wildcard, importsString, , from] = matches
 
-	// Extract imported types
+  // Extract imported types
   const imports =
-		wildcard === '*' ? ['*'] : importsString.split(',').map(d => d.trim())
+    wildcard === '*' ? ['*'] : importsString.split(',').map(d => d.trim())
 
-	// Return information about the import line
+  // Return information about the import line
   return { imports, from }
 }
 
@@ -64,11 +64,11 @@ export function parseImportLine(importLine: string): RawModule {
  */
 export function parseSDL(sdl: string): RawModule[] {
   return sdl
-		.split('\n')
-		.map(l => l.trim())
-		.filter(l => l.startsWith('# import ') || l.startsWith('#import '))
-		.map(l => l.replace('#', '').trim())
-		.map(parseImportLine)
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.startsWith('# import ') || l.startsWith('#import '))
+    .map(l => l.replace('#', '').trim())
+    .map(parseImportLine)
 }
 
 /**
@@ -78,32 +78,32 @@ export function parseSDL(sdl: string): RawModule[] {
  * @returns Single bundled schema with all imported types
  */
 export function importSchema(
-	schema: string,
-	schemas?: { [key: string]: string },
-	rootFields: string[] = ['Query', 'Mutation', 'Subscription']
+  schema: string,
+  schemas?: { [key: string]: string },
+  rootFields: string[] = ['Query', 'Mutation', 'Subscription']
 ): string {
   const sdl = read(schema, schemas) || schema
   const document = getDocumentFromSDL(sdl)
 
-	// Recursively process the imports, starting by importing all types from the initial schema
+  // Recursively process the imports, starting by importing all types from the initial schema
   let { allDefinitions, typeDefinitions } = collectDefinitions(
-		['*'],
-		sdl,
-		schema,
-		rootFields,
-		schemas,
-	)
+    ['*'],
+    sdl,
+    schema,
+    rootFields,
+    schemas,
+  )
 
-	// Post processing of the final schema (missing types, unused types, etc.)
-	// Query, Mutation and Subscription should be merged
-	// And should always be in the first set, to make sure they
-	// are not filtered out.
+  // Post processing of the final schema (missing types, unused types, etc.)
+  // Query, Mutation and Subscription should be merged
+  // And should always be in the first set, to make sure they
+  // are not filtered out.
   const firstTypes = flatten(typeDefinitions).filter(d =>
-		includes(rootFields, d.name.value),
-	)
+    includes(rootFields, d.name.value),
+  )
   const otherFirstTypes = typeDefinitions[0].filter(
-		d => !includes(rootFields, d.name.value),
-	)
+    d => !includes(rootFields, d.name.value),
+  )
   const firstSet = firstTypes.concat(otherFirstTypes)
   const processedTypeNames = []
   const mergedFirstTypes = []
@@ -113,19 +113,19 @@ export function importSchema(
       mergedFirstTypes.push(type)
     } else {
       const existingType = mergedFirstTypes.find(
-				t => t.name.value === type.name.value,
-			)
+        t => t.name.value === type.name.value,
+      )
       existingType.fields = existingType.fields.concat(
-				(type as ObjectTypeDefinitionNode).fields,
-			)
+        (type as ObjectTypeDefinitionNode).fields,
+      )
     }
   }
 
   document.definitions = completeDefinitionPool(
-		flatten(allDefinitions),
-		firstSet,
-		flatten(typeDefinitions),
-	)
+    flatten(allDefinitions),
+    firstSet,
+    flatten(typeDefinitions),
+  )
 
   const existingRootFields = rootFields.filter(x => firstTypes.find(y => y.name.value === x))
   const node = getSchemaDefinitionNode(existingRootFields)
@@ -162,10 +162,10 @@ function getDocumentFromSDL(sdl: string): DocumentNode {
  */
 function isEmptySDL(sdl: string): boolean {
   return (
-		sdl
-			.split('\n')
-			.map(l => l.trim())
-			.filter(l => !(l.length === 0 || l.startsWith('#'))).length === 0
+    sdl
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => !(l.length === 0 || l.startsWith('#'))).length === 0
   )
 }
 
@@ -183,14 +183,14 @@ function isEmptySDL(sdl: string): boolean {
  * @returns Both the collection of all type definitions, and the collection of imported type definitions
  */
 function collectDefinitions(
-	imports: string[],
-	sdl: string,
-	filePath: string,
-	rootFields: string[],
-	schemas?: { [key: string]: string },
-	processedFiles: Set<string> = new Set(),
-	typeDefinitions: ValidDefinitionNode[][] = [],
-	allDefinitions: ValidDefinitionNode[][] = [],
+  imports: string[],
+  sdl: string,
+  filePath: string,
+  rootFields: string[],
+  schemas?: { [key: string]: string },
+  processedFiles: Set<string> = new Set(),
+  typeDefinitions: ValidDefinitionNode[][] = [],
+  allDefinitions: ValidDefinitionNode[][] = [],
 ): {
   allDefinitions: ValidDefinitionNode[][]
   typeDefinitions: ValidDefinitionNode[][]
@@ -198,31 +198,31 @@ function collectDefinitions(
   const key = isFile(filePath) ? path.resolve(filePath) : filePath
   const dirname = path.dirname(filePath)
 
-	// Get TypeDefinitionNodes from current schema
+  // Get TypeDefinitionNodes from current schema
   const document = getDocumentFromSDL(sdl)
 
-	// Add all definitions to running total
+  // Add all definitions to running total
   allDefinitions.push(filterTypeDefinitions(document.definitions))
 
-	// Filter TypeDefinitionNodes by type and defined imports
+  // Filter TypeDefinitionNodes by type and defined imports
   const currentTypeDefinitions = filterImportedDefinitions(
-		imports,
-		document.definitions,
-		rootFields,
-		allDefinitions,
-	)
+    imports,
+    document.definitions,
+    rootFields,
+    allDefinitions,
+  )
 
-	// Add typedefinitions to running total
+  // Add typedefinitions to running total
   typeDefinitions.push(currentTypeDefinitions)
 
-	// Mark file as processed (for circular dependency cases)
+  // Mark file as processed (for circular dependency cases)
   processedFiles.add(key)
 
-	// Read imports from current file
+  // Read imports from current file
   const rawModules = parseSDL(sdl)
   const mergedModules: RawModule[] = []
 
-	// Merge imports from the same path
+  // Merge imports from the same path
   rawModules.forEach(m => {
     const mergedModule = mergedModules.find(mm => mm.from === m.from)
     if (mergedModule) {
@@ -232,28 +232,28 @@ function collectDefinitions(
     }
   })
 
-	// Process each file (recursively)
+  // Process each file (recursively)
   mergedModules.forEach(m => {
-		// If it was not yet processed (in case of circular dependencies)
+    // If it was not yet processed (in case of circular dependencies)
     const moduleFilePath =
-			isFile(filePath) && isFile(m.from)
-				? path.resolve(path.join(dirname, m.from))
-				: m.from
+      isFile(filePath) && isFile(m.from)
+        ? path.resolve(path.join(dirname, m.from))
+        : m.from
     if (!processedFiles.has(moduleFilePath)) {
       collectDefinitions(
-				m.imports,
-				read(moduleFilePath, schemas),
-				moduleFilePath,
-				rootFields,
-				schemas,
-				processedFiles,
-				typeDefinitions,
-				allDefinitions,
-			)
+        m.imports,
+        read(moduleFilePath, schemas),
+        moduleFilePath,
+        rootFields,
+        schemas,
+        processedFiles,
+        typeDefinitions,
+        allDefinitions,
+      )
     }
   })
 
-	// Return the maps of type definitions from each file
+  // Return the maps of type definitions from each file
   return { allDefinitions, typeDefinitions }
 }
 
@@ -266,50 +266,50 @@ function collectDefinitions(
  * @returns Filtered collection of type definitions
  */
 function filterImportedDefinitions(
-	imports: string[],
-	typeDefinitions: DefinitionNode[],
-	rootFields: string[],
-	allDefinitions: ValidDefinitionNode[][] = [],
+  imports: string[],
+  typeDefinitions: DefinitionNode[],
+  rootFields: string[],
+  allDefinitions: ValidDefinitionNode[][] = [],
 ): ValidDefinitionNode[] {
-	// This should do something smart with fields
+  // This should do something smart with fields
 
   const filteredDefinitions = filterTypeDefinitions(typeDefinitions)
 
   if (includes(imports, '*')) {
     if (
-			imports.length === 1 &&
-			imports[0] === '*' &&
-			allDefinitions.length > 1
-		) {
+      imports.length === 1 &&
+      imports[0] === '*' &&
+      allDefinitions.length > 1
+    ) {
       const previousTypeDefinitions: { [key: string]: DefinitionNode } = keyBy(
-				flatten(allDefinitions.slice(0, allDefinitions.length - 1)).filter(
-					def => !includes(rootFields, def.name.value),
-				),
-				def => def.name.value,
-			)
+        flatten(allDefinitions.slice(0, allDefinitions.length - 1)).filter(
+          def => !includes(rootFields, def.name.value),
+        ),
+        def => def.name.value,
+      )
       return typeDefinitions.filter(
-				typeDef =>
-					typeDef.kind === 'ObjectTypeDefinition' &&
-					previousTypeDefinitions[typeDef.name.value],
-			) as ObjectTypeDefinitionNode[]
+        typeDef =>
+          typeDef.kind === 'ObjectTypeDefinition' &&
+          previousTypeDefinitions[typeDef.name.value],
+      ) as ObjectTypeDefinitionNode[]
     }
     return filteredDefinitions
   } else {
     const result = filteredDefinitions.filter(d =>
-			includes(imports.map(i => i.split('.')[0]), d.name.value),
-		)
+      includes(imports.map(i => i.split('.')[0]), d.name.value),
+    )
     const fieldImports = imports.filter(i => i.split('.').length > 1)
     const groupedFieldImports = groupBy(fieldImports, x => x.split('.')[0])
 
     for (const rootType in groupedFieldImports) {
       const fields = groupedFieldImports[rootType].map(x => x.split('.')[1])
       ; (filteredDefinitions.find(
-					def => def.name.value === rootType,
-				) as ObjectTypeDefinitionNode).fields = (filteredDefinitions.find(
-					def => def.name.value === rootType,
-				) as ObjectTypeDefinitionNode).fields.filter(
-					f => includes(fields, f.name.value) || includes(fields, '*'),
-					)
+          def => def.name.value === rootType,
+        ) as ObjectTypeDefinitionNode).fields = (filteredDefinitions.find(
+          def => def.name.value === rootType,
+        ) as ObjectTypeDefinitionNode).fields.filter(
+          f => includes(fields, f.name.value) || includes(fields, '*'),
+          )
     }
 
     return result
@@ -323,7 +323,7 @@ function filterImportedDefinitions(
  * @returns Relevant type definitions
  */
 function filterTypeDefinitions(
-	definitions: DefinitionNode[],
+  definitions: DefinitionNode[],
 ): ValidDefinitionNode[] {
   const validKinds = [
     'DirectiveDefinition',
@@ -335,6 +335,6 @@ function filterTypeDefinitions(
     'InputObjectTypeDefinition',
   ]
   return definitions
-		.filter(d => includes(validKinds, d.kind))
-		.map(d => d as ValidDefinitionNode)
+    .filter(d => includes(validKinds, d.kind))
+    .map(d => d as ValidDefinitionNode)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs'
 import {
-  DefinitionNode,
-  parse,
-  print,
-  TypeDefinitionNode,
-  GraphQLObjectType,
-  ObjectTypeDefinitionNode,
-  DocumentNode,
-  Kind,
+	DefinitionNode,
+	parse,
+	print,
+	TypeDefinitionNode,
+	GraphQLObjectType,
+	ObjectTypeDefinitionNode,
+	DocumentNode,
+	Kind,
 } from 'graphql'
 import { flatten, groupBy, includes, keyBy } from 'lodash'
 import * as path from 'path'
@@ -22,8 +22,6 @@ export interface RawModule {
   imports: string[]
   from: string
 }
-
-const rootFields = ['Query', 'Mutation', 'Subscription']
 
 const read = (schema: string, schemas?: { [key: string]: string }) => {
   if (isFile(schema)) {
@@ -41,20 +39,20 @@ const isFile = f => f.endsWith('.graphql')
  * @returns Processed import line
  */
 export function parseImportLine(importLine: string): RawModule {
-  // Apply regex to import line
+	// Apply regex to import line
   const matches = importLine.match(/^import (\*|(.*)) from ('|")(.*)('|");?$/)
   if (!matches || matches.length !== 6 || !matches[4]) {
     throw new Error(`Too few regex matches: ${matches}`)
   }
 
-  // Extract matches into named variables
+	// Extract matches into named variables
   const [, wildcard, importsString, , from] = matches
 
-  // Extract imported types
+	// Extract imported types
   const imports =
-    wildcard === '*' ? ['*'] : importsString.split(',').map(d => d.trim())
+		wildcard === '*' ? ['*'] : importsString.split(',').map(d => d.trim())
 
-  // Return information about the import line
+	// Return information about the import line
   return { imports, from }
 }
 
@@ -66,11 +64,11 @@ export function parseImportLine(importLine: string): RawModule {
  */
 export function parseSDL(sdl: string): RawModule[] {
   return sdl
-    .split('\n')
-    .map(l => l.trim())
-    .filter(l => l.startsWith('# import ') || l.startsWith('#import '))
-    .map(l => l.replace('#', '').trim())
-    .map(parseImportLine)
+		.split('\n')
+		.map(l => l.trim())
+		.filter(l => l.startsWith('# import ') || l.startsWith('#import '))
+		.map(l => l.replace('#', '').trim())
+		.map(parseImportLine)
 }
 
 /**
@@ -80,30 +78,32 @@ export function parseSDL(sdl: string): RawModule[] {
  * @returns Single bundled schema with all imported types
  */
 export function importSchema(
-  schema: string,
-  schemas?: { [key: string]: string },
+	schema: string,
+	schemas?: { [key: string]: string },
+	rootFields: string[] = ['Query', 'Mutation', 'Subscription']
 ): string {
   const sdl = read(schema, schemas) || schema
   const document = getDocumentFromSDL(sdl)
 
-  // Recursively process the imports, starting by importing all types from the initial schema
+	// Recursively process the imports, starting by importing all types from the initial schema
   let { allDefinitions, typeDefinitions } = collectDefinitions(
-    ['*'],
-    sdl,
-    schema,
-    schemas,
-  )
+		['*'],
+		sdl,
+		schema,
+		rootFields,
+		schemas,
+	)
 
-  // Post processing of the final schema (missing types, unused types, etc.)
-  // Query, Mutation and Subscription should be merged
-  // And should always be in the first set, to make sure they
-  // are not filtered out.
+	// Post processing of the final schema (missing types, unused types, etc.)
+	// Query, Mutation and Subscription should be merged
+	// And should always be in the first set, to make sure they
+	// are not filtered out.
   const firstTypes = flatten(typeDefinitions).filter(d =>
-    includes(rootFields, d.name.value),
-  )
+		includes(rootFields, d.name.value),
+	)
   const otherFirstTypes = typeDefinitions[0].filter(
-    d => !includes(rootFields, d.name.value),
-  )
+		d => !includes(rootFields, d.name.value),
+	)
   const firstSet = firstTypes.concat(otherFirstTypes)
   const processedTypeNames = []
   const mergedFirstTypes = []
@@ -113,21 +113,21 @@ export function importSchema(
       mergedFirstTypes.push(type)
     } else {
       const existingType = mergedFirstTypes.find(
-        t => t.name.value === type.name.value,
-      )
+				t => t.name.value === type.name.value,
+			)
       existingType.fields = existingType.fields.concat(
-        (type as ObjectTypeDefinitionNode).fields,
-      )
+				(type as ObjectTypeDefinitionNode).fields,
+			)
     }
   }
 
   document.definitions = completeDefinitionPool(
-    flatten(allDefinitions),
-    firstSet,
-    flatten(typeDefinitions),
-  )
+		flatten(allDefinitions),
+		firstSet,
+		flatten(typeDefinitions),
+	)
 
-  // Return the schema as string
+	// Return the schema as string
   return print(document)
 }
 
@@ -157,10 +157,10 @@ function getDocumentFromSDL(sdl: string): DocumentNode {
  */
 function isEmptySDL(sdl: string): boolean {
   return (
-    sdl
-      .split('\n')
-      .map(l => l.trim())
-      .filter(l => !(l.length === 0 || l.startsWith('#'))).length === 0
+		sdl
+			.split('\n')
+			.map(l => l.trim())
+			.filter(l => !(l.length === 0 || l.startsWith('#'))).length === 0
   )
 }
 
@@ -178,13 +178,14 @@ function isEmptySDL(sdl: string): boolean {
  * @returns Both the collection of all type definitions, and the collection of imported type definitions
  */
 function collectDefinitions(
-  imports: string[],
-  sdl: string,
-  filePath: string,
-  schemas?: { [key: string]: string },
-  processedFiles: Set<string> = new Set(),
-  typeDefinitions: ValidDefinitionNode[][] = [],
-  allDefinitions: ValidDefinitionNode[][] = [],
+	imports: string[],
+	sdl: string,
+	filePath: string,
+	rootFields: string[],
+	schemas?: { [key: string]: string },
+	processedFiles: Set<string> = new Set(),
+	typeDefinitions: ValidDefinitionNode[][] = [],
+	allDefinitions: ValidDefinitionNode[][] = [],
 ): {
   allDefinitions: ValidDefinitionNode[][]
   typeDefinitions: ValidDefinitionNode[][]
@@ -192,30 +193,31 @@ function collectDefinitions(
   const key = isFile(filePath) ? path.resolve(filePath) : filePath
   const dirname = path.dirname(filePath)
 
-  // Get TypeDefinitionNodes from current schema
+	// Get TypeDefinitionNodes from current schema
   const document = getDocumentFromSDL(sdl)
 
-  // Add all definitions to running total
+	// Add all definitions to running total
   allDefinitions.push(filterTypeDefinitions(document.definitions))
 
-  // Filter TypeDefinitionNodes by type and defined imports
+	// Filter TypeDefinitionNodes by type and defined imports
   const currentTypeDefinitions = filterImportedDefinitions(
-    imports,
-    document.definitions,
-    allDefinitions,
-  )
+		imports,
+		document.definitions,
+		rootFields,
+		allDefinitions,
+	)
 
-  // Add typedefinitions to running total
+	// Add typedefinitions to running total
   typeDefinitions.push(currentTypeDefinitions)
 
-  // Mark file as processed (for circular dependency cases)
+	// Mark file as processed (for circular dependency cases)
   processedFiles.add(key)
 
-  // Read imports from current file
+	// Read imports from current file
   const rawModules = parseSDL(sdl)
   const mergedModules: RawModule[] = []
 
-  // Merge imports from the same path
+	// Merge imports from the same path
   rawModules.forEach(m => {
     const mergedModule = mergedModules.find(mm => mm.from === m.from)
     if (mergedModule) {
@@ -225,27 +227,28 @@ function collectDefinitions(
     }
   })
 
-  // Process each file (recursively)
+	// Process each file (recursively)
   mergedModules.forEach(m => {
-    // If it was not yet processed (in case of circular dependencies)
+		// If it was not yet processed (in case of circular dependencies)
     const moduleFilePath =
-      isFile(filePath) && isFile(m.from)
-        ? path.resolve(path.join(dirname, m.from))
-        : m.from
+			isFile(filePath) && isFile(m.from)
+				? path.resolve(path.join(dirname, m.from))
+				: m.from
     if (!processedFiles.has(moduleFilePath)) {
       collectDefinitions(
-        m.imports,
-        read(moduleFilePath, schemas),
-        moduleFilePath,
-        schemas,
-        processedFiles,
-        typeDefinitions,
-        allDefinitions,
-      )
+				m.imports,
+				read(moduleFilePath, schemas),
+				moduleFilePath,
+				rootFields,
+				schemas,
+				processedFiles,
+				typeDefinitions,
+				allDefinitions,
+			)
     }
   })
 
-  // Return the maps of type definitions from each file
+	// Return the maps of type definitions from each file
   return { allDefinitions, typeDefinitions }
 }
 
@@ -258,49 +261,50 @@ function collectDefinitions(
  * @returns Filtered collection of type definitions
  */
 function filterImportedDefinitions(
-  imports: string[],
-  typeDefinitions: DefinitionNode[],
-  allDefinitions: ValidDefinitionNode[][] = [],
+	imports: string[],
+	typeDefinitions: DefinitionNode[],
+	rootFields: string[],
+	allDefinitions: ValidDefinitionNode[][] = [],
 ): ValidDefinitionNode[] {
-  // This should do something smart with fields
+	// This should do something smart with fields
 
   const filteredDefinitions = filterTypeDefinitions(typeDefinitions)
 
   if (includes(imports, '*')) {
     if (
-      imports.length === 1 &&
-      imports[0] === '*' &&
-      allDefinitions.length > 1
-    ) {
+			imports.length === 1 &&
+			imports[0] === '*' &&
+			allDefinitions.length > 1
+		) {
       const previousTypeDefinitions: { [key: string]: DefinitionNode } = keyBy(
-        flatten(allDefinitions.slice(0, allDefinitions.length - 1)).filter(
-          def => !includes(rootFields, def.name.value),
-        ),
-        def => def.name.value,
-      )
+				flatten(allDefinitions.slice(0, allDefinitions.length - 1)).filter(
+					def => !includes(rootFields, def.name.value),
+				),
+				def => def.name.value,
+			)
       return typeDefinitions.filter(
-        typeDef =>
-          typeDef.kind === 'ObjectTypeDefinition' &&
-          previousTypeDefinitions[typeDef.name.value],
-      ) as ObjectTypeDefinitionNode[]
+				typeDef =>
+					typeDef.kind === 'ObjectTypeDefinition' &&
+					previousTypeDefinitions[typeDef.name.value],
+			) as ObjectTypeDefinitionNode[]
     }
     return filteredDefinitions
   } else {
     const result = filteredDefinitions.filter(d =>
-      includes(imports.map(i => i.split('.')[0]), d.name.value),
-    )
+			includes(imports.map(i => i.split('.')[0]), d.name.value),
+		)
     const fieldImports = imports.filter(i => i.split('.').length > 1)
     const groupedFieldImports = groupBy(fieldImports, x => x.split('.')[0])
 
     for (const rootType in groupedFieldImports) {
       const fields = groupedFieldImports[rootType].map(x => x.split('.')[1])
-      ;(filteredDefinitions.find(
-        def => def.name.value === rootType,
-      ) as ObjectTypeDefinitionNode).fields = (filteredDefinitions.find(
-        def => def.name.value === rootType,
-      ) as ObjectTypeDefinitionNode).fields.filter(
-        f => includes(fields, f.name.value) || includes(fields, '*'),
-      )
+      ; (filteredDefinitions.find(
+					def => def.name.value === rootType,
+				) as ObjectTypeDefinitionNode).fields = (filteredDefinitions.find(
+					def => def.name.value === rootType,
+				) as ObjectTypeDefinitionNode).fields.filter(
+					f => includes(fields, f.name.value) || includes(fields, '*'),
+					)
     }
 
     return result
@@ -314,7 +318,7 @@ function filterImportedDefinitions(
  * @returns Relevant type definitions
  */
 function filterTypeDefinitions(
-  definitions: DefinitionNode[],
+	definitions: DefinitionNode[],
 ): ValidDefinitionNode[] {
   const validKinds = [
     'DirectiveDefinition',
@@ -326,6 +330,6 @@ function filterTypeDefinitions(
     'InputObjectTypeDefinition',
   ]
   return definitions
-    .filter(d => includes(validKinds, d.kind))
-    .map(d => d as ValidDefinitionNode)
+		.filter(d => includes(validKinds, d.kind))
+		.map(d => d as ValidDefinitionNode)
 }


### PR DESCRIPTION
If we want to use custom QueryType, it wasn't possible, because there was hardcoded:
Query, Mutation, Subscription

I wanted to generate neo4j schema, they use following operationTypes:
QueryType, MutationType, SubscriptionType

and graphql-import wasn't able to identify query type, thats why I've added SCHEMA_DEFINITION support