### PR TITLE
Add `.gql` file extension support

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -744,3 +744,7 @@ test('missing type on directive', t => {
     `Directive first: Couldn't find type first in any of the schemas.`,
   )
 })
+
+test('import unerecognized module', t => {
+  t.throws(() => importSchema('fixtures/global/a.graphql'), Error)
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,12 @@ function collectDefinitions(
   const dirname = path.dirname(filePath)
 
   // Get TypeDefinitionNodes from current schema
-  const document = getDocumentFromSDL(sdl)
+  let document
+  try {
+    document = getDocumentFromSDL(sdl)
+  } catch (parseError) {
+    throw new Error(`Error in ${filePath} : ${parseError.message}`)
+  }
 
   // Add all definitions to running total
   allDefinitions.push(filterTypeDefinitions(document.definitions))

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const read = (schema: string, schemas?: { [key: string]: string }) => {
   return schemas ? schemas[schema] : schema
 }
 
-const isFile = f => f.endsWith('.graphql')
+const isFile = f => f.endsWith('.graphql') || f.endsWith('.gql')
 
 /**
  * Parse a single import line and extract imported types and schema filename

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,11 @@ function collectDefinitions(
 
   // Process each file (recursively)
   mergedModules.forEach(m => {
+    if (!isFile(m.from) && !schemas[m.from]) {
+      throw new Error(
+        `Error in ${filePath} : "${m.from}" is not a valid module. It should end with ".gql", ".graphql" or be declared in schemas collection.`
+      )
+    }
     // If it was not yet processed (in case of circular dependencies)
     const moduleFilePath =
       isFile(filePath) && isFile(m.from)


### PR DESCRIPTION
Lots of tools out there allow to use both `.graphql` and `.gql` file extensions.

Furthermore, the error returned when trying to give a file ending with `.gql` is not really helpfull since we try to parse the path as a graphql literal.

This is my very first pull request on this repo, so don't hesitate to tell me something is laking here !