### PR TITLE
feat(import): allow configuring custom root fields

### DIFF
--- a/fixtures/merged-root-fields/a.graphql
+++ b/fixtures/merged-root-fields/a.graphql
@@ -1,4 +1,4 @@
-# import Query.* from 'b.graphql'
+# import Query.*, Dummy.* from 'b.graphql'
 
 type Query {
     helloA: String

--- a/fixtures/merged-root-fields/b.graphql
+++ b/fixtures/merged-root-fields/b.graphql
@@ -10,3 +10,7 @@ type Post {
 input PostFilter {
     field3: Int
 }
+
+type Dummy {
+    field2: String
+}

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,9 +1,6 @@
 import { keyBy, uniqBy, includes } from 'lodash'
 import {
-  DocumentNode,
   TypeDefinitionNode,
-  ObjectTypeDefinitionNode,
-  InputObjectTypeDefinitionNode,
   TypeNode,
   NamedTypeNode,
   DirectiveNode,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -261,7 +261,7 @@ type C2 {
   id: ID!
 }
 `
-  t.is(importSchema(schemaA, schemas), expectedSDL)
+  t.is(importSchema(schemaA, { schemas }), expectedSDL)
 })
 
 test(`importSchema: single object schema`, t => {
@@ -324,7 +324,7 @@ type C2 {
   id: ID!
 }
 `
-  t.is(importSchema(schemaA, schemas), expectedSDL)
+  t.is(importSchema(schemaA, { schemas }), expectedSDL)
 })
 
 test(`importSchema: import all mix 'n match 2`, t => {
@@ -443,7 +443,7 @@ type C2 {
   id: ID!
 }
 `
-  t.is(importSchema(schemaA, schemas), expectedSDL)
+  t.is(importSchema(schemaA, { schemas }), expectedSDL)
 })
 
 test('importSchema: scalar', t => {
@@ -704,6 +704,31 @@ input PostFilter {
   t.is(actualSDL, expectedSDL)
 })
 
+test('merged custom root fields imports', t => {
+  const expectedSDL = `\
+type Query {
+  helloA: String
+  posts(filter: PostFilter): [Post]
+  hello: String
+}
+
+type Dummy {
+  field: String
+  field2: String
+}
+
+type Post {
+  field1: String
+}
+
+input PostFilter {
+  field3: Int
+}
+`
+  const actualSDL = importSchema('fixtures/merged-root-fields/a.graphql', { mergeableTypes: ['Dummy'] })
+  t.is(actualSDL, expectedSDL)
+})
+
 test('global schema modules', t => {
   const shared = `
     type Shared {
@@ -720,7 +745,7 @@ type Shared {
   first: String
 }
 `
-  t.is(importSchema('fixtures/global/a.graphql', { shared }), expectedSDL)
+  t.is(importSchema('fixtures/global/a.graphql', { schemas: { shared } }), expectedSDL)
 })
 
 test('missing type on type', t => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const read = (schema: string, schemas?: { [key: string]: string }) => {
   return schemas ? schemas[schema] : schema
 }
 
-const isFile = f => f.endsWith('.graphql')
+const isFile = (f: string) => f.endsWith('.graphql')
 
 /**
  * Parse a single import line and extract imported types and schema filename

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export interface RawModule {
  * Configuration options that may be passed to `importSchema`
  */
 interface ImportSchemaOptions {
-  schemas?: { [key:string]: string }
+  schemas?: { [key: string]: string }
   mergeableTypes?: [string]
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@ import {
   DefinitionNode,
   parse,
   print,
-  TypeDefinitionNode,
-  GraphQLObjectType,
   ObjectTypeDefinitionNode,
   DocumentNode,
   Kind,


### PR DESCRIPTION
> This PR stems from #42.

Allow extending the currently internal [`rootFields` array](https://github.com/prisma/graphql-import/blob/680f2dde31fb62e0b7ff929d82aa8ebad2067654/src/index.ts#L27) with a custom `mergeableTypes` array.

```js
const schema = importSchema('./schema.graphql', { mergeableTypes: ['Foo'] });
```

Types declared in `mergeableTypes` will be treated as root fields, just like `Query`, `Mutation` and `Subscription`. This effectively means: 

- They can be **imported as `Foo.*`**.
- Fields across all imported files will be **merged** together in a single type.
- Will appear at the **top of** the resulting **SDL**.

BREAKING CHANGE: `importSchema` API changed. It no longer receives `schemas` as its second, optional argument. Instead, it should be defined as a property in the new `options` argument.

```js
const schemas = { appSchema, postsSchema, commentsSchema }

// Before
const schema = importSchema('./schema.graphql', schemas)

// Now
const schema = importSchema('./schema.graphql', { schemas })
```
